### PR TITLE
Switch androidx dependency to compileOnly annotations

### DIFF
--- a/singledateandtimepicker/build.gradle
+++ b/singledateandtimepicker/build.gradle
@@ -15,7 +15,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    compileOnly "androidx.annotation:annotation:1.1.0"
 }
 
 ext {

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -3,6 +3,7 @@ package com.github.florent37.singledateandtimepicker;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.view.View;
@@ -30,7 +31,6 @@ import java.util.TimeZone;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 
 import static com.github.florent37.singledateandtimepicker.widget.SingleDateAndTimeConstants.DAYS_PADDING;
 
@@ -578,9 +578,9 @@ public class SingleDateAndTimePicker extends LinearLayout {
 
         final Resources resources = getResources();
         setTodayText(new DateWithLabel(a.getString(R.styleable.SingleDateAndTimePicker_picker_todayText), new Date()));
-        setTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_textColor, ContextCompat.getColor(context, R.color.picker_default_text_color)));
-        setSelectedTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectedTextColor, ContextCompat.getColor(context, R.color.picker_default_selected_text_color)));
-        setSelectorColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectorColor, ContextCompat.getColor(context, R.color.picker_default_selector_color)));
+        setTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_textColor, getColor(context, R.color.picker_default_text_color)));
+        setSelectedTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectedTextColor, getColor(context, R.color.picker_default_selected_text_color)));
+        setSelectorColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectorColor, getColor(context, R.color.picker_default_selector_color)));
         setSelectorHeight(a.getDimensionPixelSize(R.styleable.SingleDateAndTimePicker_picker_selectorHeight, resources.getDimensionPixelSize(R.dimen.wheelSelectorHeight)));
         setTextSize(a.getDimensionPixelSize(R.styleable.SingleDateAndTimePicker_picker_textSize, resources.getDimensionPixelSize(R.dimen.WheelItemTextSize)));
         setCurved(a.getBoolean(R.styleable.SingleDateAndTimePicker_picker_curved, IS_CURVED_DEFAULT));
@@ -610,6 +610,15 @@ public class SingleDateAndTimePicker extends LinearLayout {
             updateDaysOfMonth(now);
         }
         daysPicker.updateAdapter(); // For MustBeFuture and dayCount
+    }
+
+    private int getColor(Context context, int id) {
+        if (Build.VERSION.SDK_INT >= 23) {
+            return context.getColor(id);
+        } else {
+            //noinspection deprecation
+            return context.getResources().getColor(id);
+        }
     }
 
     public interface OnDateChangedListener {


### PR DESCRIPTION
I started [fixing the current issues in version 2.2.0 and saw that you already have submitted a PR (that basically includes [the changes I found for fixing the bugs](https://github.com/arberg/SingleDateAndTimePicker/compare/5e27fcf...14aab2b)). Hope it gets accepted soon. Maybe you can include changes to the dependencies.

I changed the appcompat dependency to compileOnly annotation.